### PR TITLE
Update memory offsets and fix issues with 64-bit platforms

### DIFF
--- a/BnS_ACT_Plugin/BNS_ACT_Plugin.cs
+++ b/BnS_ACT_Plugin/BNS_ACT_Plugin.cs
@@ -463,21 +463,21 @@ namespace BNS_ACT_Plugin
                 throw new ApplicationException("ReadProcessMemory returned incorrect byte count.  Expected: [" + Length.ToString() + "].  Actual: [" + bytesRead.ToString() + "].");
         }
 
-        private static Int32 ReadInt32(IntPtr ProcessHandle, IntPtr Offset)
+        private static UInt32 ReadUInt32(IntPtr ProcessHandle, IntPtr Offset)
         {
-            const int dataSize = sizeof(Int32);
+            const int dataSize = sizeof(UInt32);
             byte[] buffer = new byte[dataSize];
             IntPtr bytesRead = IntPtr.Zero;
 
             if (!ReadProcessMemory(ProcessHandle, Offset, buffer, new IntPtr(dataSize), ref bytesRead))
                 return 0;
 
-            return BitConverter.ToInt32(buffer, 0);
+            return BitConverter.ToUInt32(buffer, 0);
         }
 
         private static IntPtr ReadIntPtr(IntPtr ProcessHandle, IntPtr Offset)
         {
-            return new IntPtr(ReadInt32(ProcessHandle, Offset));
+            return new IntPtr(ReadUInt32(ProcessHandle, Offset));
         }
 
     }


### PR DESCRIPTION
Reading pointers as signed integers caused them to get sign extended in IntPtr constructor on 64-bit platforms, closes #3.

Also updated offsets and improved string reading, while chat log lines will probably never be shorter than 8 characters, it can be useful in future, closes #12.
